### PR TITLE
Add pkg-config package to build image

### DIFF
--- a/metadata_test.go
+++ b/metadata_test.go
@@ -115,6 +115,7 @@ func testMetadata(t *testing.T, context spec.G, it spec.S) {
 				ContainSubstring("Package: libyaml-0-2"),
 				ContainSubstring("Package: netbase"),
 				ContainSubstring("Package: openssl"),
+				ContainSubstring("Package: pkg-config"),
 				ContainSubstring("Package: tzdata"),
 				ContainSubstring("Package: xz-utils"),
 				ContainSubstring("Package: zlib1g-dev"),

--- a/stack/stack.toml
+++ b/stack/stack.toml
@@ -29,6 +29,7 @@ platforms = ["linux/amd64"]
     libyaml-0-2 \
     netbase \
     openssl \
+    pkg-config \
     tzdata \
     xz-utils \
     zlib1g-dev \


### PR DESCRIPTION
## Summary / Use Cases

This PR adds pkg-config library. See https://github.com/paketo-buildpacks/jammy-base-stack/pull/92 for discussion of a similar change for the base stack.

I think this library should exist for this stack because the same use-cases apply to this stack as well.

See also https://github.com/paketo-buildpacks/jammy-tiny-stack/pull/110 for the equivalent in the tiny stack

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
