### PR TITLE
Build stack images as single layer

### DIFF
--- a/stack/build.Dockerfile
+++ b/stack/build.Dockerfile
@@ -4,9 +4,8 @@ ARG sources
 ARG packages
 ARG package_args='--no-install-recommends'
 
-RUN echo "$sources" > /etc/apt/sources.list
-
-RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selections && \
+RUN echo "$sources" > /etc/apt/sources.list && \
+  echo "debconf debconf/frontend select noninteractive" | debconf-set-selections && \
   export DEBIAN_FRONTEND=noninteractive && \
   apt-get -y $package_args update && \
   apt-get -y $package_args upgrade && \
@@ -14,9 +13,7 @@ RUN echo "debconf debconf/frontend select noninteractive" | debconf-set-selectio
   locale-gen en_US.UTF-8 && \
   update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8 && \
   apt-get -y $package_args install $packages && \
-  rm -rf /var/lib/apt/lists/* /tmp/*
-
-RUN for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done
-
-RUN curl -sSfL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 \
-  && chmod +x /usr/local/bin/yj
+  rm -rf /var/lib/apt/lists/* /tmp/* && \
+  for path in /workspace /workspace/source-ws /workspace/source; do git config --system --add safe.directory "${path}"; done && \
+  curl -sSfL -o /usr/local/bin/yj https://github.com/sclevine/yj/releases/latest/download/yj-linux-amd64 && \
+  chmod +x /usr/local/bin/yj


### PR DESCRIPTION
## Summary
This PR builds the stack images as a single layer each, on top of the upstream base layer.

- we want as few layers as possible, and most of the layers are small and change infrequently so we should not separate them out.
- making the layers a single layer in the Dockerfile is the easiest way to achieve a minimal number of layers. Tools like crane flatten would also squash the base layer which we prefer to keep separate.

## Use Cases

Reducing the number of layers in the stack results in more layers available in builders. Some container runtimes (e.g. docker) have layer limits that Paketo Builders can run into.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
